### PR TITLE
25 docker error could not find or load main class orgspringframeworkbootloaderjarlauncher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ ENV APP_VERSION=${VERSION} \
     SPRING_PROFILES_ACTIVE="prod"
 EXPOSE 8080
 
-ENTRYPOINT ["java", "-XX:MaxRAMPercentage=90", "org.springframework.boot.loader.JarLauncher"]
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=90", "org.springframework.boot.loader.launch.JarLauncher"]
 
 HEALTHCHECK --interval=25s --timeout=3s --retries=2 CMD ["java", "HealthCheck.java", "||", "exit", "1"]
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ repositories {
 
 ext {
     set('springBootVersion', "3.2.1")
-    set('springCloudVersion', "2022.0.4")
+    set('springCloudVersion', "2023.0.0")
     set("hapiFhirVersion", "6.8.5")
 }
 


### PR DESCRIPTION
Error
```
Error: Could not find or load main class org.springframework.boot.loader.JarLauncher
Caused by: java.lang.ClassNotFoundException: org.springframework.boot.loader.JarLauncher
```

Dockerfile:
```
ENTRYPOINT ["java", "-XX:MaxRAMPercentage=90", "org.springframework.boot.loader.JarLauncher"]
```

`JarLauncher` was moved to `org.springframework.boot.loader.launch` package.