### PR TITLE
HL7 mapper only maps the first note for an observation

### DIFF
--- a/src/main/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapper.java
+++ b/src/main/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapper.java
@@ -138,7 +138,7 @@ public class Hl7LabMapper extends BaseMapper<ORU_R01> {
 
             var obr = order.getOBR();
             var obx = order.getOBSERVATION().getOBX();
-            var nte = order.getOBSERVATION().getNTE();
+            var nte = order.getOBSERVATION().getNTEAll();
 
             // code
             var code =
@@ -189,9 +189,10 @@ public class Hl7LabMapper extends BaseMapper<ORU_R01> {
                         obs.getValue())).map(List::of).orElse(null))
 
                 // note
-                .setNote(Arrays.stream(nte.getComment())
-                    .map(n -> new Annotation().setText(n.getValue()))
-                    .toList());
+                .setNote(
+                    nte.stream().flatMap(n -> Arrays.stream(n.getComment()))
+                        .map(c -> new Annotation().setText(c.getValue()))
+                        .toList());
 
             result.add(obs);
 

--- a/src/test/resources/reports/test.hl7
+++ b/src/test/resources/reports/test.hl7
@@ -13,6 +13,7 @@ OBX|1|NM|EBVA^Epstein-Barr-Virus VCA-IgG||40.56~positiv|S/CO|0.75 - <1.00|H|||F
 OBR|5|20190417_55555555|||||20190417111000||||||||||||||||||F
 OBX|1|NM|EBEA^Epstein-Barr-Virus EBNA IgG||20.95~positiv|S/CO|0.50 - <1.00|H|||F
 NTE|1||Beurteilung: abgelaufene Infektion
+NTE|2||Test
 OBR|6|20190417_55555555|||||20190417111000||||||||||||||||||R
 OBX|1|NM|APTT^aPTT||31|sec|23 - 38||||R
 OBR|7|20190417_55555555|||||20190417111000||||||||||||||||||F


### PR DESCRIPTION
Only the first NTE segment for an observation is currently mapped.