### PR TITLE
Handle duplicate observations

### DIFF
--- a/dev/test-data.hl7
+++ b/dev/test-data.hl7
@@ -42,3 +42,7 @@ OBX|1|NM|EBVA^Epstein-Barr-Virus VCA-IgG||40.56~positiv|S/CO|0.75 - <1.00|H|||F
 OBR|5|20190417_55555555|||||20190417111000||||||||||||||||||F
 OBX|1|NM|EBEA^Epstein-Barr-Virus EBNA IgG||20.95~positiv|S/CO|0.50 - <1.00|H|||F
 NTE|1||Beurteilung: abgelaufene Infektion
+OBR|6|20190417_55555555|||||20190417111000||||||||||||||||||F
+OBX|1|ST|HST^Harnstoff||folgt||||||I
+OBR|7|20190417_55555555|||||20190417111000||||||||||||||||||F
+OBX|1|ST|HST^Harnstoff||folgt||||||I

--- a/src/main/java/de/unimarburg/diz/labtofhir/mapper/BaseMapper.java
+++ b/src/main/java/de/unimarburg/diz/labtofhir/mapper/BaseMapper.java
@@ -174,8 +174,6 @@ abstract class BaseMapper<T> implements ValueMapper<T, Bundle> {
         var idElement = resource.getIdElement()
             .getValue();
         bundle.addEntry()
-            .setFullUrl(resource.getResourceType()
-                .name() + "/" + idElement)
             .setResource(resource)
             .setRequest(
                 new Bundle.BundleEntryRequestComponent().setMethod(

--- a/src/main/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapper.java
+++ b/src/main/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapper.java
@@ -127,7 +127,7 @@ public class Hl7LabMapper extends BaseMapper<ORU_R01> {
         return bundle;
     }
 
-    private List<Observation> mapObservations(ORU_R01 msg) throws
+    List<Observation> mapObservations(ORU_R01 msg) throws
         HL7Exception {
 
         var result = new ArrayList<Observation>();
@@ -158,9 +158,25 @@ public class Hl7LabMapper extends BaseMapper<ORU_R01> {
                         .getValueAsDate());
 
             // identifier
-            var identifierValue =
+            var obsId =
                 createObsId(msg.getMSH().getSendingApplication().getValue(),
                     getRequestNumber(msg), code, effective);
+            // check duplicate
+            var dup =
+                result.stream()
+                    .filter(o -> o.getIdentifierFirstRep().getValue()
+                        .equals(obsId)).count();
+            // check duplicates
+            String identifierValue;
+            if (dup > 0) {
+                identifierValue =
+                    createObsId(msg.getMSH().getSendingApplication().getValue(),
+                        getRequestNumber(msg), String.format("%s_%d", code,
+                            dup),
+                        effective);
+            } else {
+                identifierValue = obsId;
+            }
 
             var obs = createObservation(identifierValue);
 

--- a/src/test/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapperTests.java
+++ b/src/test/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapperTests.java
@@ -112,7 +112,7 @@ public class Hl7LabMapperTests {
 
     @SuppressWarnings("checkstyle:LineLength")
     @Test
-    void parseValueMapsNumericRangeToString() throws HL7Exception, IOException {
+    void parseValueMapsNumericRangeToString() throws HL7Exception {
 
         var msg = """
             MSH|^~\\&|SWISSLAB|KLIN|DBSERV||20220702120811|LAB|ORU^R01|test-msg.000000|P|2.2|||AL|NE\r
@@ -129,6 +129,31 @@ public class Hl7LabMapperTests {
             var actual = mapper.parseValue(obx);
 
             assertThat(actual.primitiveValue()).isEqualTo("3-9");
+        }
+    }
+
+    @SuppressWarnings("checkstyle:LineLength")
+    @Test
+    void duplicateObservationCodesAreMapped() throws HL7Exception {
+
+        var msg = """
+            MSH|^~\\&|SWISSLAB|KLIN|DBSERV||20220702120811|LAB|ORU^R01|test-msg.000000|P|2.2|||AL|NE\r
+            OBR|1|20220702_88888888|||||20220702120811||||||||||||||||||F\r
+            OBX|1|ST|HST^Harnstoff||folgt||||||I\r
+            OBR|2|20220702_88888888|||||20220702120811||||||||||||||||||F\r
+            OBX|2|ST|HST^Harnstoff||folgt||||||I
+            """;
+
+        try (var deserializer = new Hl7Deserializer<>()) {
+            var oru = (ORU_R01) deserializer.deserialize(null,
+                msg.getBytes(StandardCharsets.UTF_8));
+            var actual = mapper.mapObservations(oru);
+
+            assertThat(actual).hasSize(2);
+            // observations have different identifier values
+            assertThat(
+                actual.get(0).getIdentifierFirstRep().getValue()).isNotEqualTo(
+                actual.get(1).getIdentifierFirstRep().getValue());
         }
     }
 

--- a/src/test/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapperTests.java
+++ b/src/test/java/de/unimarburg/diz/labtofhir/mapper/Hl7LabMapperTests.java
@@ -137,10 +137,10 @@ public class Hl7LabMapperTests {
     void duplicateObservationCodesAreMapped() throws HL7Exception {
 
         var msg = """
-            MSH|^~\\&|SWISSLAB|KLIN|DBSERV||20220702120811|LAB|ORU^R01|test-msg.000000|P|2.2|||AL|NE\r
-            OBR|1|20220702_88888888|||||20220702120811||||||||||||||||||F\r
+            MSH|^~\\&|SWISSLAB|KLIN|DBSERV||20240702120811|LAB|ORU^R01|test-msg.blubb|P|2.2|||AL|NE\r
+            OBR|1|bla|||||20240702120811||||||||||||||||||F\r
             OBX|1|ST|HST^Harnstoff||folgt||||||I\r
-            OBR|2|20220702_88888888|||||20220702120811||||||||||||||||||F\r
+            OBR|2|bla|||||20240702120811||||||||||||||||||F\r
             OBX|2|ST|HST^Harnstoff||folgt||||||I
             """;
 


### PR DESCRIPTION
HL7 OBX segments with identical values (apart form its segment numbers) are currently mapped with the same generated identifier values. 

Those should be mapped to different Observations with different ids.